### PR TITLE
Prevent rebuilding on install: recipe

### DIFF
--- a/patches/0001-makefile-Add-install-target-and-build-the-module-by-.patch
+++ b/patches/0001-makefile-Add-install-target-and-build-the-module-by-.patch
@@ -27,7 +27,7 @@ index 44c7bb83981a..2fee5e096b51 100755
  clean:
  	$(MAKE) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) clean
  
-+install: modules
++install:
 +	$(MAKE) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) INSTALL_MOD_PATH=$(INSTALL_MOD_PATH) modules_install
 +
  kernelrelease:


### PR DESCRIPTION
Building and installing as stated in README.md, with:
./build.sh -r r6p2 -b
./build.sh -r r6p2 -i

results in building twice the driver.
Install recipe requires modules.

Remove modules dependency on install recipe from patch