### PR TITLE
build and install with same arguments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,13 @@
 
 RELEASE=r6p0
 
+BUILD_OPTS="USING_UMP=0
+	    BUILD=release
+	    USING_PROFILING=0
+	    MALI_PLATFORM=sunxi
+	    USING_DVFS=1
+	    USING_DEVFREQ=1"
+
 apply_patches() {
     pushd $2
 
@@ -16,8 +23,7 @@ apply_patches() {
 build_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    USING_UMP=0 BUILD=release USING_PROFILING=0 MALI_PLATFORM=sunxi \
-	     USING_DVFS=1 USING_DEVFREQ=1 make -C $driver_dir
+    make $BUILD_OPTS -C $driver_dir
 
     cp $driver_dir/mali.ko .
 }
@@ -25,8 +31,7 @@ build_driver() {
 install_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    USING_UMP=0 BUILD=release USING_PROFILING=0 MALI_PLATFORM=sunxi \
-	     USING_DVFS=0 make -C $driver_dir install
+    make $BUILD_OPTS -C $driver_dir install
 }
 
 while getopts "r:aubi" opt


### PR DESCRIPTION
Build and install with same arguments.
This is to prevent to recompile driver twice.

Issueing:
./build.sh -r r6p2 -b
compiles
./build.sh -r r6p2 -i
compiles again, because arguments passed to Makefile are different then previous command