### PR TITLE
Fix bulding driver twice.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,13 @@
 
 RELEASE=r6p0
 
+BUILD_OPTS="USING_UMP=0
+	    BUILD=release
+	    USING_PROFILING=0
+	    MALI_PLATFORM=sunxi
+	    USING_DVFS=1
+	    USING_DEVFREQ=1"
+
 apply_patches() {
     pushd $2
 
@@ -16,8 +23,7 @@ apply_patches() {
 build_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    USING_UMP=0 BUILD=release USING_PROFILING=0 MALI_PLATFORM=sunxi \
-	     USING_DVFS=1 USING_DEVFREQ=1 make -C $driver_dir
+    make $BUILD_OPTS -C $driver_dir
 
     cp $driver_dir/mali.ko .
 }
@@ -25,8 +31,7 @@ build_driver() {
 install_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    USING_UMP=0 BUILD=release USING_PROFILING=0 MALI_PLATFORM=sunxi \
-	     USING_DVFS=0 make -C $driver_dir install
+    make $BUILD_OPTS -C $driver_dir install
 }
 
 while getopts "r:aubi" opt


### PR DESCRIPTION
Building and installing build driver twice.

This is because build_driver() and install_driver()
have different make build options.

Add global variable for build options unique for both
build_driver() and install_driver().

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>