### PR TITLE
Fix 0014-mali-Make-devfreq-optional.patch

### DIFF
--- a/patches/0013-mali-support-building-against-4.15.patch
+++ b/patches/0013-mali-support-building-against-4.15.patch
@@ -108,7 +108,7 @@ Signed-off-by: John Stultz <john.stultz@linaro.org>
  	MALI_DEBUG_ASSERT_POINTER(tim);
 -	tim->timer.data = (unsigned long)data;
 -	tim->timer.function = (timer_timeout_function_t)callback;
-+	timer_setup(&tim->timer, callback, 0);
++	__setup_timer(&tim->timer, callback, &tim->timer, 0);
  }
  
  void _mali_osk_timer_term(_mali_osk_timer_t *tim)

--- a/patches/0014-mali-Make-devfreq-optional.patch
+++ b/patches/0014-mali-Make-devfreq-optional.patch
@@ -15,10 +15,10 @@ Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>
  r6p2/src/devicedrv/mali/linux/mali_devfreq.c | 7 +++++--
  1 file changed, 5 insertions(+), 2 deletions(-)
 
-diff --git a/r6p2/src/devicedrv/mali/linux/mali_devfreq.c b/r6p2/src/devicedrv/mali/linux/mali_devfreq.c
+diff --git a/src/devicedrv/mali/linux/mali_devfreq.c b/src/devicedrv/mali/linux/mali_devfreq.c
 index 0b0ba1481eed..c3a2636e6635 100755
---- a/r6p2/src/devicedrv/mali/linux/mali_devfreq.c
-+++ b/r6p2/src/devicedrv/mali/linux/mali_devfreq.c
+--- a/src/devicedrv/mali/linux/mali_devfreq.c
++++ b/src/devicedrv/mali/linux/mali_devfreq.c
 @@ -232,8 +232,11 @@ int mali_devfreq_init(struct mali_device *mdev)
  	dp->get_cur_freq = mali_devfreq_cur_freq;
  	dp->exit = mali_devfreq_exit;


### PR DESCRIPTION
0014-mali-Make-devfreq-optional.patch can't be applied

This is due to wrong path specified inside the patch
that doesn't take into account mali version to be patched

Removed r6p2 from every path inside patch

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>