### PR TITLE
Add parallel building by default and -j option to override jobs number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ export INSTALL_MOD_PATH=$TARGET_DIR
 It should install the mali.ko Linux kernel module into the target filesystem,
 and the module should be loaded automatically. If it isn't, modprobe will help.
 
+Module is compiled using parallel build by default.
+To override jobs number, use -j option as follows:
+
+```
+./build.sh -r r6p2 -j 8 -b
+```
+Where 8 is the number of simultaneous jobs.
+
 ## Installing the user-space components
 
 Once the driver is compiled and loaded, you'll need to integrate the OpenGL ES

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RELEASE=r6p0
-
+JOBS=$(nproc)
 BUILD_OPTS="USING_UMP=0
 	    BUILD=release
 	    USING_PROFILING=0
@@ -40,7 +40,7 @@ unapply_patches() {
 build_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    make $BUILD_OPTS -C $driver_dir
+    make JOBS=$JOBS $BUILD_OPTS -C $driver_dir
     if [ $? -ne 0 ]; then
 	    echo "Error building the driver"
 	    exit 1
@@ -52,16 +52,16 @@ build_driver() {
 install_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    make $BUILD_OPTS -C $driver_dir install
+    make JOBS=$JOBS $BUILD_OPTS -C $driver_dir install
 }
 
 clean_driver() {
     local driver_dir=$(pwd)/$RELEASE/src/devicedrv/mali/
 
-    make $BUILD_OPTS -C $driver_dir clean
+    make JOBS=$JOBS $BUILD_OPTS -C $driver_dir clean
 }
 
-while getopts "r:aubcit" opt
+while getopts "j:r:aubcit" opt
 do
     case $opt in
 	a)
@@ -81,6 +81,9 @@ do
 	i)
 	    echo "installing..."
 	    install_driver $RELEASE
+	    ;;
+	j)
+	    JOBS=$OPTARG
 	    ;;
 	r)
 	    case $OPTARG in

--- a/patches/0015-Enable-parallel-building-passing-variable-to-Makefile.patch
+++ b/patches/0015-Enable-parallel-building-passing-variable-to-Makefile.patch
@@ -1,0 +1,43 @@
+From f54c82f4732035296e252a0a4368efa56549ba35 Mon Sep 17 00:00:00 2001
+From: Giulio Benetti <giulio.benetti@micronovasrl.com>
+Date: Fri, 5 Jan 2018 23:01:02 +0100
+Subject: [PATCH] Enable parallel building passing variable to Makefile.
+
+Add JOBS variable to driver's Makefile.
+JOBS variable will contain the jobs number to use when calling sub-make.
+
+Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>
+---
+ src/devicedrv/mali/Makefile | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/devicedrv/mali/Makefile b/src/devicedrv/mali/Makefile
+index 66a2b28..c3790a0 100755
+--- a/src/devicedrv/mali/Makefile
++++ b/src/devicedrv/mali/Makefile
+@@ -194,18 +194,18 @@ EXTRA_DEFINES += -DMALI_MEM_SWAP_TRACKING=1
+ endif
+ 
+ modules: $(UMP_SYMVERS_FILE)
+-	$(MAKE) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) modules
++	$(MAKE) -j$(JOBS) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) modules
+ 	@rm $(FILES_PREFIX)__malidrv_build_info.c $(FILES_PREFIX)__malidrv_build_info.o
+ 
+ all: modules
+ 
+ clean:
+-	$(MAKE) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) clean
++	$(MAKE) -j$(JOBS) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) clean
+ 
+ install: modules
+-	$(MAKE) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) INSTALL_MOD_PATH=$(INSTALL_MOD_PATH) modules_install
++	$(MAKE) -j$(JOBS) ARCH=$(ARCH) -C $(KDIR) M=$(CURDIR) INSTALL_MOD_PATH=$(INSTALL_MOD_PATH) modules_install
+ 
+ kernelrelease:
+-	$(MAKE) ARCH=$(ARCH) -C $(KDIR) kernelrelease
++	$(MAKE) -j$(JOBS) ARCH=$(ARCH) -C $(KDIR) kernelrelease
+ 
+ export CONFIG KBUILD_EXTRA_SYMBOLS
+-- 
+2.7.4
+


### PR DESCRIPTION
Building can be faster.

Parallel building is now by default and jobs number = nproc
To override jobs number, pass -j <N> option where N is jobs number.

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>