### PR TITLE
Add 0015 parallel build patch to quilt series

### DIFF
--- a/patches/r6p0/series
+++ b/patches/r6p0/series
@@ -10,3 +10,4 @@ r6p0/0009-mali-Fix-user-memory-domain-fault.patch
 r6p0/0011-mali-support-building-against-4.13.patch
 0012-mali-support-building-against-4.14.patch
 r6p0/0013-mali-support-building-against-4.15.patch
+0015-Enable-parallel-building-passing-variable-to-Makefile.patch

--- a/patches/r6p2/series
+++ b/patches/r6p2/series
@@ -12,3 +12,4 @@ r6p2/0011-mali-support-building-against-4.13.patch
 0012-mali-support-building-against-4.14.patch
 r6p2/0013-mali-support-building-against-4.15.patch
 r6p2/0014-mali-Make-devfreq-optional.patch
+0015-Enable-parallel-building-passing-variable-to-Makefile.patch


### PR DESCRIPTION
After adding quilt to handle patches,
patch 0015 has been left out from "series" files.

Add it to "series" files and get parallel compilation back working

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>