### PR TITLE
Fixed - implict declaration - 4.19-rc2

### DIFF
--- a/r6p2/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/r6p2/src/devicedrv/mali/linux/mali_osk_time.c
@@ -54,6 +54,6 @@ u64 _mali_osk_time_get_ns(void)
 u64 _mali_osk_boot_time_get_ns(void)
 {
 	struct timespec tsval;
-	getboottime(&tsval);
+	tsval = ktime_to_timespec(ktime_get_boottime());
 	return (u64)timespec_to_ns(&tsval);
 }

--- a/r6p2/src/devicedrv/mali/linux/mali_osk_time.c
+++ b/r6p2/src/devicedrv/mali/linux/mali_osk_time.c
@@ -54,6 +54,6 @@ u64 _mali_osk_time_get_ns(void)
 u64 _mali_osk_boot_time_get_ns(void)
 {
 	struct timespec tsval;
-	get_monotonic_boottime(&tsval);
+	getboottime(&tsval);
 	return (u64)timespec_to_ns(&tsval);
 }


### PR DESCRIPTION
get_monotonic_boottime