### PR TITLE
mali: support building against 5.0

### DIFF
--- a/patches/0019-mali-support-building-against-5.0.patch
+++ b/patches/0019-mali-support-building-against-5.0.patch
@@ -1,0 +1,64 @@
+From 5a9bdf22d0f4b091f2c2c9178250d1e1ba0b6f6c Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <roman.stratiienko@globallogic.com>
+Date: Wed, 23 Jan 2019 23:15:19 +0200
+Subject: [PATCH] mali: support building against 5.0
+
+Since kernel v5.0 upstream commit 96d4f267e40f
+("Remove 'type' argument from access_ok() function")
+ access_ok() funcion takes only 2 parameters
+
+Create wrapper for access_ok() that drops first parameter in case of
+linux v5.0 and later, and preserves it for earlier version
+
+Replace all access_ok() calls with _access_ok() wrapper
+
+Signed-off-by: Roman Stratiienko <roman.stratiienko@globallogic.com>
+---
+ src/devicedrv/mali/linux/mali_kernel_linux.h | 6 ++++++
+ src/devicedrv/mali/linux/mali_ukk_mem.c      | 6 +++---
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/devicedrv/mali/linux/mali_kernel_linux.h b/src/devicedrv/mali/linux/mali_kernel_linux.h
+index f858a5c..d545732 100755
+--- a/src/devicedrv/mali/linux/mali_kernel_linux.h
++++ b/src/devicedrv/mali/linux/mali_kernel_linux.h
+@@ -38,6 +38,12 @@ extern int vm_insert_pfn(struct vm_area_struct *vma, unsigned long addr,
+ 			 unsigned long pfn);
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
++#define _access_ok(TYPE, BUF, SIZE) access_ok(BUF, SIZE)
++#else
++#define _access_ok(TYPE, BUF, SIZE) access_ok(TYPE, BUF, SIZE)
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/src/devicedrv/mali/linux/mali_ukk_mem.c b/src/devicedrv/mali/linux/mali_ukk_mem.c
+index ca1cba0..4769dea 100755
+--- a/src/devicedrv/mali/linux/mali_ukk_mem.c
++++ b/src/devicedrv/mali/linux/mali_ukk_mem.c
+@@ -202,8 +202,8 @@ int mem_write_safe_wrapper(struct mali_session_data *session_data, _mali_uk_mem_
+ 	kargs.ctx = (uintptr_t)session_data;
+ 
+ 	/* Check if we can access the buffers */
+-	if (!access_ok(VERIFY_WRITE, kargs.dest, kargs.size)
+-	    || !access_ok(VERIFY_READ, kargs.src, kargs.size)) {
++	if (!_access_ok(VERIFY_WRITE, kargs.dest, kargs.size)
++	    || !_access_ok(VERIFY_READ, kargs.src, kargs.size)) {
+ 		return -EINVAL;
+ 	}
+ 
+@@ -261,7 +261,7 @@ int mem_dump_mmu_page_table_wrapper(struct mali_session_data *session_data, _mal
+ 		goto err_exit;
+ 
+ 	user_buffer = (void __user *)(uintptr_t)kargs.buffer;
+-	if (!access_ok(VERIFY_WRITE, user_buffer, kargs.size))
++	if (!_access_ok(VERIFY_WRITE, user_buffer, kargs.size))
+ 		goto err_exit;
+ 
+ 	/* allocate temporary buffer (kernel side) to store mmu page table info */
+-- 
+2.19.1
+

--- a/patches/r6p0/series
+++ b/patches/r6p0/series
@@ -12,3 +12,4 @@ r6p0/0011-mali-support-building-against-4.13.patch
 r6p0/0013-mali-support-building-against-4.15.patch
 0015-Enable-parallel-building-passing-variable-to-Makefile.patch
 0018-mali-support-building-against-4.20.patch
+0019-mali-support-building-against-5.0.patch

--- a/patches/r6p2/series
+++ b/patches/r6p2/series
@@ -15,3 +15,4 @@ r6p2/0014-mali-Make-devfreq-optional.patch
 0015-Enable-parallel-building-passing-variable-to-Makefile.patch
 r6p2/0016-mali-support-building-against-4.16.patch
 0018-mali-support-building-against-4.20.patch
+0019-mali-support-building-against-5.0.patch

--- a/patches/r8p1/series
+++ b/patches/r8p1/series
@@ -10,3 +10,4 @@ r6p2/0014-mali-Make-devfreq-optional.patch
 r6p2/0016-mali-support-building-against-4.16.patch
 r8p1/0017-mali-support-building-against-4.9-later.patch
 0018-mali-support-building-against-4.20.patch
+0019-mali-support-building-against-5.0.patch


### PR DESCRIPTION
Since kernel v5.0 upstream commit 96d4f267e40f
("Remove 'type' argument from access_ok() function")
 access_ok() funcion takes only 2 parameters

Create wrapper for access_ok() that drops first parameter in case of
linux v5.0 and later, and preserves it for earlier version

Replace all access_ok() calls with _access_ok() wrapper