### PR TITLE
travis: Switch to xenial for a newer gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+dist: xenial
 
 addons:
   apt:

--- a/travis-base.yml
+++ b/travis-base.yml
@@ -1,4 +1,5 @@
 language: c
+dist: xenial
 
 addons:
   apt:


### PR DESCRIPTION
The gcc version in trusty is blacklisted by some kernel version which
result in false-negative reports in Travis.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>