### PR TITLE
Add allwinner A64 support 

### DIFF
--- a/patches/r6p2/0020-mali-support-building-against-4.17.patch
+++ b/patches/r6p2/0020-mali-support-building-against-4.17.patch
@@ -1,0 +1,20 @@
+--- r6p2/src/devicedrv/mali/linux/mali_memory.c	2019-03-19 13:23:39.740056345 +0100
++++ r6p2/src/devicedrv/mali/linux/mali_memory.c	2019-03-19 13:25:17.284057010 +0100
+@@ -57,10 +57,14 @@
+ 	vma->vm_private_data = NULL;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+-static int mali_mem_vma_fault(struct vm_fault *vmf)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
++    static vm_fault_t mali_mem_vma_fault(struct vm_fault *vmf)
+ #else
+-static int mali_mem_vma_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
++    #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++    static int mali_mem_vma_fault(struct vm_fault *vmf)
++    #else
++    static int mali_mem_vma_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
++    #endif
+ #endif
+ {
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)

--- a/patches/r6p2/0021-Add-A64-support.patch
+++ b/patches/r6p2/0021-Add-A64-support.patch
@@ -1,0 +1,26 @@
+--- a/src/devicedrv/mali/platform/sunxi/sunxi.c	2019-02-06 11:13:20.116079157 +0100
++++ b/src/devicedrv/mali/platform/sunxi/sunxi.c	2019-02-06 11:10:52.000000000 +0100
+@@ -38,6 +38,7 @@
+ 	return of_device_is_compatible(np, "allwinner,sun4i-a10-mali") ||
+ 		of_device_is_compatible(np, "allwinner,sun7i-a20-mali") ||
+ 		of_device_is_compatible(np, "allwinner,sun8i-h3-mali") ||
++		of_device_is_compatible(np, "allwinner,sun50i-a64-mali") ||
+ 		of_device_is_compatible(np, "allwinner,sun50i-h5-mali");
+ }
+ 
+@@ -123,6 +124,7 @@
+ 	{ .compatible = "allwinner,sun4i-a10-mali" },
+ 	{ .compatible = "allwinner,sun7i-a20-mali" },
+ 	{ .compatible = "allwinner,sun8i-h3-mali" },
++	{ .compatible = "allwinner,sun50i-a64-mali" },
+ 	{ .compatible = "allwinner,sun50i-h5-mali" },
+ 	{ /* sentinel */ },
+ };
+@@ -311,6 +313,7 @@
+ 	}
+ 
+ 	if (of_device_is_compatible(np, "allwinner,sun8i-h3-mali") ||
++	    of_device_is_compatible(np, "allwinner,sun50i-a64-mali")||
+ 	    of_device_is_compatible(np, "allwinner,sun50i-h5-mali"))
+ 		clk_set_rate(mali->core_clk, 576000000);
+ 	else if (of_device_is_compatible(np, "allwinner,sun7i-a20-mali") ||

--- a/patches/r6p2/series
+++ b/patches/r6p2/series
@@ -16,3 +16,4 @@ r6p2/0014-mali-Make-devfreq-optional.patch
 r6p2/0016-mali-support-building-against-4.16.patch
 0018-mali-support-building-against-4.20.patch
 0019-mali-support-building-against-5.0.patch
+r6p2/0020-mali-support-building-against-4.17.patch

--- a/patches/r6p2/series
+++ b/patches/r6p2/series
@@ -17,3 +17,4 @@ r6p2/0016-mali-support-building-against-4.16.patch
 0018-mali-support-building-against-4.20.patch
 0019-mali-support-building-against-5.0.patch
 r6p2/0020-mali-support-building-against-4.17.patch
+r6p2/0021-Add-A64-support.patch


### PR DESCRIPTION
… incompatible pointer type

Signed-off-by: John-Eric Kamps <john-eric.kamps@honeywell.com>

I fixed a problem to compile Mali GPU on Allwinner A64 with the latest 5.0 Linux kernel.